### PR TITLE
Fix bottom row arrow support

### DIFF
--- a/firmware/minisub/minisub.h
+++ b/firmware/minisub/minisub.h
@@ -6,11 +6,11 @@
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, \
     K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, \
     K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, \
-    K30, K31, K32,           K33, K37,           K38, K39, K3B  \
+    K30, K31, K32,           K33, K37,      K38, K39, K3A, K3B  \
 ) \
 { \
     { K00,   K01,   K02,   K03,  K04,   K05,   K06,   K07,   K08,   K09,   K0A,   K0B }, \
     { K10,   K11,   K12,   K13,  K14,   K15,   K16,   K17,   K18,   K19,   K1A,   K1B }, \
     { K20,   K21,   K22,   K23,  K24,   K25,   K26,   K27,   K28,   K29,   K2A,   K2B }, \
-    { K30,   K31,   K32,   K33,  KC_NO, KC_NO, KC_NO, K37,   K38,   K39,   KC_NO, K3B }  \
+    { K30,   K31,   K32,   K33,  KC_NO, KC_NO, KC_NO, K37,   K38,   K39,   K3A,   K3B }  \
 }


### PR DESCRIPTION
Without this, it was not possible for me to map the last three keys in the bottom row. My use case was using them as arrow keys in a split space layout.